### PR TITLE
Make module consumable via TypeScript in other projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,90 @@
+{
+  "name": "uint8array-json-parser",
+  "version": "0.0.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "0.0.1",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "2.4.2",
+        "uglify-js": "3.0.27"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
+      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.0.27",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.27.tgz",
+      "integrity": "sha512-HD8CmxPXUI62v5tweiulMcP/apAtx1DXGcNZkhKQZyC+MTrTsoCBb8yPAwVrbvpgw3EpRU76bRe6axjIiCYcQg==",
+      "dev": true,
+      "dependencies": {
+        "commander": "~2.11.0",
+        "source-map": "~0.5.1"
+      },
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    }
+  },
+  "dependencies": {
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
+      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "3.0.27",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.27.tgz",
+      "integrity": "sha512-HD8CmxPXUI62v5tweiulMcP/apAtx1DXGcNZkhKQZyC+MTrTsoCBb8yPAwVrbvpgw3EpRU76bRe6axjIiCYcQg==",
+      "dev": true,
+      "requires": {
+        "commander": "~2.11.0",
+        "source-map": "~0.5.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "tsc && uglifyjs -cm -o uint8array-json-parser.min.js -- uint8array-json-parser.js"
   },
   "main": "uint8array-json-parser.js",
+  "types": "uint8array-json-parser.d.ts",
   "devDependencies": {
     "typescript": "2.4.2",
     "uglify-js": "3.0.27"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "tsc && uglifyjs -cm -o uint8array-json-parser.min.js -- uint8array-json-parser.js"
   },
   "main": "uint8array-json-parser.js",
-  "dependencies": {
+  "devDependencies": {
     "typescript": "2.4.2",
     "uglify-js": "3.0.27"
   }

--- a/uint8array-json-parser.d.ts
+++ b/uint8array-json-parser.d.ts
@@ -1,0 +1,7 @@
+export function JSON_parse(array: Uint8Array): any;
+
+// It might seem weird to have a declaration file here given that the project is
+// written in TypeScript, but it seems like uint8array-json-parser.ts was
+// written in a way to minimize the minified size of the code. Unfortunately,
+// the tricks it uses to do that make the TypeScript typechecker real unhappy
+// when this module is imported, so we direct it to ignore that file.


### PR DESCRIPTION
Hi Evan! I needed this module for https://github.com/jlfwong/speedscope/pull/385, so figured I would fix it up a little while I'm here.

Before this change, trying to import this module into a TypeScript file would yield the following error:

```
node_modules/@types/node/globals.d.ts:171:13 - error TS2451: Cannot redeclare block-scoped variable 'exports'.

171 declare var exports: any;
                ~~~~~~~

  node_modules/uint8array-json-parser/uint8array-json-parser.ts:1:15
    1 declare const exports: any;
                    ~~~~~~~
    'exports' was also declared here.

node_modules/uint8array-json-parser/uint8array-json-parser.ts:1:15 - error TS2451: Cannot redeclare block-scoped variable 'exports'.

1 declare const exports: any;
                ~~~~~~~

  node_modules/@types/node/globals.d.ts:171:13
    171 declare var exports: any;
                    ~~~~~~~
    'exports' was also declared here.

node_modules/uint8array-json-parser/uint8array-json-parser.ts:3:2 - error TS1345: An expression of type 'void' cannot be tested for truthiness

  3 !function(exports: any) {
     ~~~~~~~~~~~~~~~~~~~~~~~~
  4   const enum State {
    ~~~~~~~~~~~~~~~~~~~~
...
418   };
    ~~~~
419 }(typeof exports !== 'undefined' ? exports : this);
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 3 errors.
```

I could have just re-written the TypeScript file to not use this pattern, but it was presumably done like this for a reason. When I changed it to not use the closure around `exports`, the minified file got bigger. So I decided to do the more conservative thing and just fix TypeScript compatibility.

This PR also does two other things (which could be split into other PRs)
1. Move uglify and typescript from `dependencies` to `devDependencies`
2. Checks in the `package-lock.json` file, since it became an untracked file as soon as I ran `npm install`. It could alternatively be gitignored, but it seems like this is best practice at the moment.